### PR TITLE
Better syntax for optional / required dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,5 +39,5 @@ const walker = new Walker(modulePath);
 Returns `Promise<Module[]>`
 
 Will walk your entire node_modules tree reporting back an array of "modules", each
-module has a "path", "name" and "depType".  See the typescript definition file
+module has a "path", "name" and "relationship".  See the typescript definition file
 for more information.

--- a/src/depTypes.ts
+++ b/src/depTypes.ts
@@ -1,43 +1,41 @@
 export enum DepType {
   PROD,
   DEV,
+  ROOT,
+}
+
+export enum DepRequireState {
   OPTIONAL,
-  DEV_OPTIONAL,
-  ROOT
+  REQUIRED,
+}
+
+export class DepRelationship {
+  constructor(private type: DepType, private required: DepRequireState) {}
+
+  public getType() { return this.type; }
+  public getRequired() { return this.required; }
+  public toString() {
+    return `${DepType[this.getType()]}_${DepRequireState[this.getRequired()]}`;
+  }
+}
+
+export const depRequireStateGreater = (newState: DepRequireState, existing: DepRequireState) => {
+  if (existing === DepRequireState.REQUIRED) {
+    return false;
+  } else if (newState === DepRequireState.REQUIRED) {
+    return true;
+  }
+  return false;
 }
 
 export const depTypeGreater = (newType: DepType, existing: DepType) => {
   switch (existing) {
     case DepType.DEV:
       switch (newType) {
-        case DepType.OPTIONAL:
         case DepType.PROD:
         case DepType.ROOT:
           return true;
         case DepType.DEV:
-        case DepType.DEV_OPTIONAL:
-        default:
-          return false;
-      }
-    case DepType.DEV_OPTIONAL:
-      switch (newType) {
-        case DepType.OPTIONAL:
-        case DepType.PROD:
-        case DepType.ROOT:
-        case DepType.DEV:
-          return true;
-        case DepType.DEV_OPTIONAL:
-        default:
-          return false;
-      }
-    case DepType.OPTIONAL:
-      switch (newType) {
-        case DepType.PROD:
-        case DepType.ROOT:
-          return true;
-        case DepType.OPTIONAL:
-        case DepType.DEV:
-        case DepType.DEV_OPTIONAL:
         default:
           return false;
       }
@@ -46,9 +44,7 @@ export const depTypeGreater = (newType: DepType, existing: DepType) => {
         case DepType.ROOT:
           return true;
         case DepType.PROD:
-        case DepType.OPTIONAL:
         case DepType.DEV:
-        case DepType.DEV_OPTIONAL:
         default:
           return false;
       }
@@ -56,9 +52,7 @@ export const depTypeGreater = (newType: DepType, existing: DepType) => {
       switch (newType) {
         case DepType.ROOT:
         case DepType.PROD:
-        case DepType.OPTIONAL:
         case DepType.DEV:
-        case DepType.DEV_OPTIONAL:
         default:
           return false;
       }
@@ -67,22 +61,18 @@ export const depTypeGreater = (newType: DepType, existing: DepType) => {
   }
 }
 
-export const childDepType = (parentType: DepType, childType: DepType) => {
-  if (childType === DepType.ROOT) {
-    throw new Error('Something went wrong, a child dependency can\'t be marked as the ROOT');
+export const depRelationshipGreater = (newRelationship: DepRelationship, existingRelationship: DepRelationship) => {
+  if (depRequireStateGreater(newRelationship.getRequired(), existingRelationship.getRequired())) {
+    return true;
   }
-  switch (parentType) {
-    case DepType.ROOT:
-      return childType;
-    case DepType.PROD:
-      if (childType === DepType.OPTIONAL) return DepType.OPTIONAL;
-      return DepType.PROD;
-    case DepType.OPTIONAL:
-      return DepType.OPTIONAL;
-    case DepType.DEV_OPTIONAL:
-      return DepType.DEV_OPTIONAL;
-    case DepType.DEV:
-      if (childType === DepType.OPTIONAL) return DepType.DEV_OPTIONAL;
-      return DepType.DEV;
+  return depTypeGreater(newRelationship.getType(), existingRelationship.getType());
+}
+
+export const childRequired = (parent: DepRequireState, child: DepRequireState) => {
+  switch (parent) {
+    case DepRequireState.OPTIONAL:
+      return DepRequireState.OPTIONAL;
+    default:
+      return child;
   }
 }

--- a/test/Walker_spec.ts
+++ b/test/Walker_spec.ts
@@ -2,7 +2,7 @@ import * as path from 'path';
 import { expect } from 'chai';
 
 import { Module, Walker } from '../src/Walker';
-import { DepType } from '../src/depTypes';
+import { DepType, DepRequireState } from '../src/depTypes';
 
 describe('Walker', () => {
   let walker: Walker;
@@ -18,26 +18,31 @@ describe('Walker', () => {
     expect(walker.getRootModule()).to.equal(path.resolve(__dirname, '..'));
   });
 
-  it('should locate top level prod deps as prod deps', () => {
-    expect(dep('fs-extra')).to.have.property('depType', DepType.PROD);
+  it('should locate top level prod deps as required prod deps', () => {
+    expect(dep('fs-extra').relationship.getType()).equal(DepType.PROD);
+    expect(dep('fs-extra').relationship.getRequired()).equal(DepRequireState.REQUIRED);
   });
 
-  it('should locate top level dev deps as dev deps', () => {
-    expect(dep('mocha')).to.have.property('depType', DepType.DEV);
+  it('should locate top level dev deps as required dev deps', () => {
+    expect(dep('mocha').relationship.getType()).equal(DepType.DEV);
+    expect(dep('mocha').relationship.getRequired()).equal(DepRequireState.REQUIRED);
   });
 
-  it('should locate a dep of a dev dep as a dev dep', () => {
-    expect(dep('commander')).to.have.property('depType', DepType.DEV);
+  it('should locate a dep of a dev dep as a required dev dep', () => {
+    expect(dep('commander').relationship.getType()).equal(DepType.DEV);
+    expect(dep('commander').relationship.getRequired()).equal(DepRequireState.REQUIRED);
   });
 
-  it('should locate a dep of a dev dep that is also a top level prod dep as a prod dep', () => {
-    expect(dep('debug')).to.have.property('depType', DepType.PROD);
+  it('should locate a dep of a dev dep that is also a top level prod dep as a required prod dep', () => {
+    expect(dep('debug').relationship.getType()).equal(DepType.PROD);
+    expect(dep('debug').relationship.getRequired()).equal(DepRequireState.REQUIRED);
   });
 
-  it('should locate a dep of a dev dep that is optional as a dev_optional dep', function () {
+  it('should locate a dep of a dev dep that is optional as an optional dev dep', function () {
     if (process.platform !== 'darwin') {
       this.skip();
     }
-    expect(dep('fsevents')).to.have.property('depType', DepType.DEV_OPTIONAL);
+    expect(dep('fsevents').relationship.getType()).to.equal(DepType.DEV);
+    expect(dep('fsevents').relationship.getRequired()).to.equal(DepRequireState.OPTIONAL);
   });
 });

--- a/test/depTypes_spec.ts
+++ b/test/depTypes_spec.ts
@@ -1,63 +1,45 @@
 import { expect } from 'chai';
 
-import { DepType, childDepType, depTypeGreater } from '../src/depTypes';
+import { DepType, DepRequireState, childRequired, depTypeGreater, depRequireStateGreater } from '../src/depTypes';
 
 describe('depTypes', () => {
-  describe('enum', () => {
+  describe('DepType enum', () => {
     it('should contain unique numbers', () => {
       expect(
         Object.keys(DepType)
           .map(key => DepType[key])
           .filter(value => typeof value === 'number')
           .length
-      ).to.equal(5);
+      ).to.equal(3);
     });
   });
 
-  describe('childDepType', () => {
-    it('should throw an error if you try to calculate the child type of a "root" child', () => {
-      expect(() => childDepType(DepType.PROD, DepType.ROOT)).to.throw();
+  describe('DepRequireState enum', () => {
+    it('should contain unique numbers', () => {
+      expect(
+        Object.keys(DepRequireState)
+          .map(key => DepRequireState[key])
+          .filter(value => typeof value === 'number')
+          .length
+      ).to.equal(2);
     });
+  });
 
+  describe('childRequired', () => {
     it('should mark children of optional deps as optional', () => {
-      expect(childDepType(DepType.OPTIONAL, DepType.DEV)).to.equal(DepType.OPTIONAL);
-      expect(childDepType(DepType.OPTIONAL, DepType.PROD)).to.equal(DepType.OPTIONAL);
-      expect(childDepType(DepType.OPTIONAL, DepType.OPTIONAL)).to.equal(DepType.OPTIONAL);
+      expect(childRequired(DepRequireState.OPTIONAL, DepRequireState.REQUIRED)).to.equal(DepRequireState.OPTIONAL);
     });
 
-    it('should mark non-optional deps of prod deps as prod', () => {
-      expect(childDepType(DepType.PROD, DepType.DEV)).to.equal(DepType.PROD);
-      expect(childDepType(DepType.PROD, DepType.PROD)).to.equal(DepType.PROD);
+    it('should mark required children of required deps as required', () => {
+      expect(childRequired(DepRequireState.REQUIRED, DepRequireState.REQUIRED)).to.equal(DepRequireState.REQUIRED);
     });
 
-    it('should mark optional deps of prod deps as optional', () => {
-      expect(childDepType(DepType.PROD, DepType.OPTIONAL)).to.equal(DepType.OPTIONAL);
-    });
-
-    it('should mark non-optional deps of dev deps as dev', () => {
-      expect(childDepType(DepType.DEV, DepType.PROD)).to.equal(DepType.DEV);
-      expect(childDepType(DepType.DEV, DepType.DEV)).to.equal(DepType.DEV);
-    });
-
-    // THIS IS REQUIRED BEHAVIOR, DO NOT CHANGE
-    // For future context, this is just so we don't leave around optional transitive
-    // deps.  Using dev_optional is :ok: because it ensures that we don't keep them
-    it('should mark optional deps of dev deps as dev_optional deps', () => {
-      expect(childDepType(DepType.DEV, DepType.OPTIONAL)).to.equal(DepType.DEV_OPTIONAL);
-    });
-
-    it('should mark deps of the root project as their native dep type', () => {
-      expect(childDepType(DepType.ROOT, DepType.DEV)).to.equal(DepType.DEV);
-      expect(childDepType(DepType.ROOT, DepType.OPTIONAL)).to.equal(DepType.OPTIONAL);
-      expect(childDepType(DepType.ROOT, DepType.PROD)).to.equal(DepType.PROD);
+    it('should mark optional children of required deps as optional', () => {
+      expect(childRequired(DepRequireState.REQUIRED, DepRequireState.OPTIONAL)).to.equal(DepRequireState.OPTIONAL);
     });
   });
 
   describe('depTypeGreater', () => {
-    it('should report OPTIONAL > DEV', () => {
-      expect(depTypeGreater(DepType.OPTIONAL, DepType.DEV)).to.equal(true);
-    });
-
     it('should report PROD > DEV', () => {
       expect(depTypeGreater(DepType.PROD, DepType.DEV)).to.equal(true);
     });
@@ -66,24 +48,8 @@ describe('depTypes', () => {
       expect(depTypeGreater(DepType.ROOT, DepType.DEV)).to.equal(true);
     });
 
-    it('should report DEV < OPTIONAL', () => {
-      expect(depTypeGreater(DepType.DEV, DepType.OPTIONAL)).to.equal(false);
-    });
-
-    it('should report PROD > OPTIONAL', () => {
-      expect(depTypeGreater(DepType.PROD, DepType.OPTIONAL)).to.equal(true);
-    });
-
-    it('should report ROOT > OPTIONAL', () => {
-      expect(depTypeGreater(DepType.ROOT, DepType.OPTIONAL)).to.equal(true);
-    });
-
     it('should report DEV < PROD', () => {
       expect(depTypeGreater(DepType.DEV, DepType.PROD)).to.equal(false);
-    });
-
-    it('should report OPTIONAL < PROD', () => {
-      expect(depTypeGreater(DepType.OPTIONAL, DepType.PROD)).to.equal(false);
     });
 
     it('should report ROOT > PROD', () => {
@@ -94,12 +60,29 @@ describe('depTypes', () => {
       expect(depTypeGreater(DepType.DEV, DepType.ROOT)).to.equal(false);
     });
 
-    it('should report OPTIONAL < ROOT', () => {
-      expect(depTypeGreater(DepType.OPTIONAL, DepType.ROOT)).to.equal(false);
-    });
-
     it('should report PROD < ROOT', () => {
       expect(depTypeGreater(DepType.PROD, DepType.ROOT)).to.equal(false);
+    });
+  });
+
+  describe('depRequireStateGreater', () => {
+    it('should report REQUIRED > OPTIONAL', () => {
+      expect(depRequireStateGreater(DepRequireState.REQUIRED, DepRequireState.OPTIONAL)).to.equal(true);
+    });
+
+    it('should report OPTIONAL < REQUIRED', () => {
+      expect(depRequireStateGreater(DepRequireState.OPTIONAL, DepRequireState.REQUIRED)).to.equal(false);
+    });
+
+    /**
+     * These tests ensure that the method will not modify things that are identical
+     */
+    it('should report OPTIONAL < OPTIONAL', () => {
+      expect(depRequireStateGreater(DepRequireState.OPTIONAL, DepRequireState.OPTIONAL)).to.equal(false);
+    });
+
+    it('should report OPTIONAL < REQUIRED', () => {
+      expect(depRequireStateGreater(DepRequireState.REQUIRED, DepRequireState.REQUIRED)).to.equal(false);
     });
   });
 });


### PR DESCRIPTION
Basically modules now have a `relationship` property which is an instance of the [`DepRelationship`](https://github.com/MarshallOfSound/flora-colossus/pull/4/files#diff-3d4c95d0e36d3aeab797f4525ad171f6R12) class which has the documented API.

```js
getType(): DepType // The old depType value without OPTIONAL and DEV_OPTIONAL
getRequired(): DepRequireState // Optional vs Required
```

Tests have been updated accordingly