### PR TITLE
Follow symlinks (to support PNPM)

### DIFF
--- a/src/Walker.ts
+++ b/src/Walker.ts
@@ -51,7 +51,7 @@ export class Walker {
   }
 
   private async walkDependenciesForModuleInModule(moduleName: string, modulePath: string, depType: DepType) {
-    let testPath = modulePath;
+    let testPath = await fs.realpath(modulePath);
     let discoveredPath: string | null = null;
     let lastRelative: string | null = null;
     // Try find it while searching recursively up the tree

--- a/src/Walker.ts
+++ b/src/Walker.ts
@@ -25,6 +25,7 @@ export class Walker {
   private rootModule: string;
   private modules: Module[];
   private walkHistory: Set<string> = new Set();
+  private realPaths: Map<string, string> = new Map();
 
   constructor(modulePath: string) {
     if (!modulePath || typeof modulePath !== 'string') {
@@ -51,7 +52,11 @@ export class Walker {
   }
 
   private async walkDependenciesForModuleInModule(moduleName: string, modulePath: string, depType: DepType) {
-    let testPath = await fs.realpath(modulePath);
+    let testPath = this.realPaths.get(modulePath);
+    if (!testPath) {
+      testPath = await fs.realpath(modulePath);
+      this.realPaths.set(modulePath, testPath);
+    }
     let discoveredPath: string | null = null;
     let lastRelative: string | null = null;
     // Try find it while searching recursively up the tree


### PR DESCRIPTION
At the moment, this doesn't work at all with PNPM, since it relies on Node following symlinks during module resolution. So I've made it follow symlinks.

It does seem to be a bit slower, if that's a concern:
Before, `yarn` `node_modules`: 400ms
After, `yarn` `node_modules`: 850ms
After, `pnpm` `node_modules`: 2.3s