### PR TITLE
Optionally skip devDependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,10 @@ Returns `Promise<Module[]>`
 Will walk your entire node_modules tree reporting back an array of "modules", each
 module has a "path", "name" and "depType".  See the typescript definition file
 for more information.
+
+By default, walkTree will walk through all devDependencies and throw an error if any devDependency is not found in node_modules. You can force the walker to skip devDependencies by settig the environment variable `WALKER_IGNORE_DEV_DEPENDENCIES".
+
+Example (Mac):
+```
+export WALKER_IGNORE_DEV_DEPENDENCIES=true
+```

--- a/src/Walker.ts
+++ b/src/Walker.ts
@@ -1,6 +1,7 @@
 import * as debug from 'debug';
 import * as fs from 'fs-extra';
 import * as path from 'path';
+import * as process from 'process';
 
 import { DepType, depTypeGreater, childDepType } from './depTypes';
 import { NativeModuleType } from './nativeModuleTypes';
@@ -25,6 +26,7 @@ export class Walker {
   private rootModule: string;
   private modules: Module[];
   private walkHistory: Set<string> = new Set();
+  private ignoreDevDependencies: boolean;
 
   constructor(modulePath: string) {
     if (!modulePath || typeof modulePath !== 'string') {
@@ -32,6 +34,7 @@ export class Walker {
     }
     d(`creating walker with rootModule=${modulePath}`);
     this.rootModule = modulePath;
+    this.ignoreDevDependencies = process.env.WALKER_IGNORE_DEV_DEPENDENCIES?true:false;
   }
 
   private relativeModule(rootPath: string, moduleName: string) {
@@ -45,6 +48,7 @@ export class Walker {
       if (!pJ.dependencies) pJ.dependencies = {};
       if (!pJ.devDependencies) pJ.devDependencies = {};
       if (!pJ.optionalDependencies) pJ.optionalDependencies = {};
+      if(this.ignoreDevDependencies) delete pJ.devDependencies;
       return pJ;
     }
     return null;

--- a/test/Walker_spec.ts
+++ b/test/Walker_spec.ts
@@ -1,4 +1,5 @@
 import * as path from 'path';
+import * as process from 'process';
 import { expect } from 'chai';
 
 import { Module, Walker } from '../src/Walker';
@@ -47,6 +48,31 @@ describe('Walker', () => {
         return;
       }
       expect(dep('fsevents')).to.have.property('depType', DepType.DEV_OPTIONAL);
+    });
+  });
+
+  describe('WALKER_IGNORE_DEV_DEPENDENCIES', () => {
+    let modules: Module[];
+    const thisPackageDir = path.resolve(__dirname, '..');
+    const dep = (depName: string) => modules.find(module => module.name === depName);
+  
+    it('should save root directory correctly', () => {
+      const walker = new Walker(thisPackageDir)
+      expect(walker.getRootModule()).to.equal(thisPackageDir);
+    });
+  
+    describe('depType', () => {
+      beforeEach(async () => {
+        process.env.WALKER_IGNORE_DEV_DEPENDENCIES = "true";
+        modules = await buildWalker(path.resolve(__dirname, '..'));
+      });
+      afterEach(async () => {
+        delete process.env.WALKER_IGNORE_DEV_DEPENDENCIES;
+      });
+  
+      it('should skip dev dependency', () => {
+        expect(dep('mocha')).to.not.exist;
+      });
     });
   });
 


### PR DESCRIPTION
When an electron application is delivered as an npm package rather than a repo, the devDependencies associated with that package will not be available. The tree walker throws an exception even though we likely were going to prune those devDependencies anyway inside electron-packager.

Now, the walker will skip devDependencies if the environment variable WALKER_IGNORE_DEV_DEPENDENCIES is set.

_Note: it might be better if Walker accepted a constructor argument rather than an environment variable but that would require coordinated pull requests across `flora-colossus`, `galactus` and `electron-packager`. This might be MoS's preferred approach though._