### PR TITLE
Allow walking from non-root dependencies

### DIFF
--- a/src/Walker.ts
+++ b/src/Walker.ts
@@ -160,13 +160,13 @@ export class Walker {
   }
 
   private cache: Promise<Module[]> | null = null;
-  async walkTree() {
+  async walkTree(depType = DepType.ROOT) {
     d('starting tree walk');
     if (!this.cache) {
       this.cache = new Promise<Module[]>(async (resolve, reject) => {
         this.modules = [];
         try {
-          await this.walkDependenciesForModule(this.rootModule, DepType.ROOT);
+          await this.walkDependenciesForModule(this.rootModule, depType);
         } catch (err) {
           reject(err);
           return;


### PR DESCRIPTION
Currently `flora-colossus` can only walk from the root module and expects devDeps of that modules to exist. 

I have [been attempting to use it to walk dependencies of production dependencies](https://github.com/electron-userland/electron-forge/pull/2345/files#diff-5aa20b5d44781ead4f39a054063539430c33c0a0fbe2bc12c6feb02f123d3edeR42-R45), however when starting from the root it fails because devDeps of production deps are missing.

This change allows you to override the kind of dependency you are starting from.
